### PR TITLE
OLED: define SPISend

### DIFF
--- a/firmware/monezor/inc/display.h
+++ b/firmware/monezor/inc/display.h
@@ -58,4 +58,6 @@ void oledSwipeRight(void);
 
 char oledConvertChar(const char c);
 
+void SPISend(uint32_t base, uint8_t *data, int len);
+
 #endif


### PR DESCRIPTION
Adds definition for SPISend.

Fixes the following compilation failure in master: 
```
$ make                                                                                                                               
src/display.o: In function `oledRefresh':                                                                                                   
kastelo/firmware/monezor/src/display.c:204: undefined reference to `SPISend'                                                  
kastelo/firmware/monezor/src/display.c:209: undefined reference to `SPISend'                                                  
src/display.o: In function `oledInit':                                                                                                      
kastelo/firmware/monezor/src/display.c:168: undefined reference to `SPISend'                                                  
collect2: error: ld returned 1 exit status                                                                                                  
make: *** [../libopencm3.rules.mk:202: monezor.elf] Error 1
```
